### PR TITLE
Added capital or lowercase use for strip_sweep function (Fast) or (fast) its all accepted now

### DIFF
--- a/sweepai/handlers/on_ticket.py
+++ b/sweepai/handlers/on_ticket.py
@@ -136,11 +136,11 @@ def post_process_snippets(
 def strip_sweep(text: str):
     return (
         re.sub(
-            r"^[Ss]weep\s?(\(slow\))?(\(migrate\))?(\(fast\))?\s?:", "", text
+            r"^[Ss]weep\s?(\([Ss]low\))?(\([Mm]igrate\))?(\([Ff]ast\))?\s?:", "", text
         ).lstrip(),
-        re.search(r"^[Ss]weep\s?\(slow\)", text) is not None,
-        re.search(r"^[Ss]weep\s?\(migrate\)", text) is not None,
-        re.search(r"^[Ss]weep\s?\(fast\)", text) is not None,
+        re.search(r"^[Ss]weep\s?\([Ss]low\)", text) is not None,
+        re.search(r"^[Ss]weep\s?\([Mm]igrate\)", text) is not None,
+        re.search(r"^[Ss]weep\s?\([Ff]ast\)", text) is not None,
     )
 
 


### PR DESCRIPTION
# Purpose

I made this many user is can use as Fast or Slow because the Sweep or sweep is accepted. But currently system now recognize Fast.

# Changes Made
I added [Ff] [Ss] [Mm] to regex.