### PR TITLE
Added document and test mode to issue comment section

### DIFF
--- a/sweepai/handlers/on_ticket.py
+++ b/sweepai/handlers/on_ticket.py
@@ -87,6 +87,11 @@ ordinal = lambda n: str(n) + (
 )
 
 
+# Document and test mode text
+predefined_document_mode = ""
+predefined_test_mode = ""
+
+
 def post_process_snippets(
     snippets: list[Snippet],
     max_num_of_snippets: int = 5,
@@ -132,7 +137,7 @@ def post_process_snippets(
     return result_snippets[:max_num_of_snippets]
 
 
-def strip_sweep(text: str):
+def strip_sweep_title(text: str):
     return (
         re.sub(
             r"^[Ss]weep\s?(\([Ss]low\))?(\([Mm]igrate\))?(\([Ff]ast\))?\s?:", "", text
@@ -140,6 +145,15 @@ def strip_sweep(text: str):
         re.search(r"^[Ss]weep\s?\([Ss]low\)", text) is not None,
         re.search(r"^[Ss]weep\s?\([Mm]igrate\)", text) is not None,
         re.search(r"^[Ss]weep\s?\([Ff]ast\)", text) is not None,
+    )
+
+def strip_sweep_summary(text: str):
+    #Sweep(Document)
+    #Sweep(Test)
+    return (
+        re.sub(r"^[Ss]weep\s?(\([Dd]ocument\))?(\([Tt]est\))?\s?", "", text).lstrip(), 
+        re.search(r"^[Ss]weep\s?\([Dd]ocument\)", text) is not None, 
+        re.search(r"^[Ss]weep\s?\([Tt]est\)", text) is not None
     )
 
 
@@ -159,7 +173,14 @@ async def on_ticket(
         slow_mode,
         migrate,
         fast_mode,
-    ) = strip_sweep(title)
+    ) = strip_sweep_title(title)
+
+    # Getting summary document_mode and test_mode information
+    (
+        summary,
+        document_mode,
+        test_mode,
+    ) = strip_sweep_summary(summary)
 
     # Flow:
     # 1. Get relevant files
@@ -173,6 +194,14 @@ async def on_ticket(
         "<details>\n<summary>Checklist</summary>.*", "", summary, flags=re.DOTALL
     )
     summary = re.sub("Checklist:\n\n- \[[ X]\].*", "", summary, flags=re.DOTALL)
+
+
+    #Adding predefined text to summpart
+
+    if document_mode:
+        summary = predefined_document_mode + summary
+    elif test_mode:
+        summary = predefined_test_mode + summary
 
     repo_name = repo_full_name
 


### PR DESCRIPTION
# Purpose

With the merge we can able to setting prefined modes for sweep like 

- Issue title: Sweep(Fast): ...
- [NEW] Issue comment. Sweep(Document) ...

Results:
- Fast mode enabled
- [NEW] Document mode enabled

# Changes Made

- A changed `strip_sweep` function name with `strip_sweep_title`
- A added a `strip_sweep_summary` function for analyzing an extracting document and test mode from summary
- A added a predefined variables to top of `on_ticket.py`
- A added a section in `on_ticket` function for implementing the predefined mode text to top of summary text