### PR TITLE
docs: update orphaned `examples` links to the correct target

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Describe bugs, small features, and refactors like you would to a junior develope
 
 ### Why Choose Sweep?
 
-We're not a toy project or a proof-of-concept. We're a **production devtool** used by startups including ourselves to ship features everyday, with example features [here](https://docs.sweep.dev/examples).
+We're not a toy project or a proof-of-concept. We're a **production devtool** used by startups including ourselves to ship features everyday, with example features [here](https://docs.sweep.dev/about/examples).
 Unlike Copilot, which only provides IDE-based autocompletion, Sweep handles the **entire flow end-to-end**. Unlike ChatGPT, Sweep is able to automatically understand and search through your code base, removing the need to tediously copy-and-paste files.
 
 <details>
@@ -96,7 +96,7 @@ Unlike existing AI solutions, this can solve entire tickets and can be paralleli
 - Modal Labs for infra + deployment
 
 ## Highlights
-Examine pull requests created by Sweep [here](https://docs.sweep.dev/examples).
+Examine pull requests created by Sweep [here](https://docs.sweep.dev/about/examples).
 
 ## Pricing
 Every user receives unlimited GPT-3.5 tickets and 5 GPT-4 tickets per month. To prevent abuse, users can use 2 GPT-4 tickets a day.

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -101,7 +101,7 @@ We access your GitHub repository at runtime. At the end of execution, your code 
 <details>
 <summary>Do you have example Sweep PRs?</summary>
 
-Yes! Check out [https://docs.sweep.dev/examples](https://docs.sweep.dev/examples).
+Yes! Check out [https://docs.sweep.dev/about/examples](https://docs.sweep.dev/about/examples).
 
 </details>
 


### PR DESCRIPTION
Accidentally stumbled across 2 of these 3 dead links while doomscrolling. (Well I promised in the discord ~3m ago that I’d send a PR if I ever found an issue, I just didn’t expect it to be this pedantic hehe)

#1356 Almost managed to get it right but missed two occurrences; which is still impressive. Good work y’all!