### PR TITLE
fixed broken links in docs

### DIFF
--- a/docs/pages/usage/advanced.mdx
+++ b/docs/pages/usage/advanced.mdx
@@ -27,11 +27,11 @@ We highly recommend linters, as well as Netlify/Vercel preview builds. Sweep aut
 ### Set up `sweep.yaml`
 
 You can set up `sweep.yaml` to
-* Provide up to date docs by setting up `docs` (https://docs.sweep.dev/config#docs)
-* Set up automated formatting and linting by setting up `sandbox` (https://docs.sweep.dev/config#sandbox). Never have Sweep commit a failing `npm lint` again.
+* Provide up to date docs by setting up `docs` (https://docs.sweep.dev/usage/config#docs)
+* Set up automated formatting and linting by setting up `sandbox` (https://docs.sweep.dev/usage/config#sandbox). Never have Sweep commit a failing `npm lint` again.
 * Give Sweep a high level description of where to find files in your repo by editing the `repo_description` field.
 
-For more on configs, check out https://docs.sweep.dev/config.
+For more on configs, check out https://docs.sweep.dev/usage/config.
 
 ## Prompting 🗣️
 


### PR DESCRIPTION
# Purpose

This PR fixes three links on the advanced page which were broken because they didn't match the latest directory structure.

# Changes Made

Please provide a detailed list of the changes made in this pull request.

1. added /usage/ to path in three links in advanced.mdx