### PR TITLE
Fix .replit config 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.pythonlibs
 
 # Spyder project settings
 .spyderproject

--- a/.replit
+++ b/.replit
@@ -1,4 +1,5 @@
 run = "redis-server --bind 0.0.0.0 --port 6379 & uvicorn sweepai.api:app --host 0.0.0.0 --port 8080 --workers 5"
+modules = ["python-3.10:v18-20230807-322e88b"]
 
 hidden = [".pythonlibs"]
 
@@ -7,3 +8,4 @@ channel = "stable-23_05"
 
 [deployment]
 run = ["sh", "-c", "redis-server --bind 0.0.0.0 --port 6379 & uvicorn sweepai.api:app --host 0.0.0.0 --port 8080 --workers 5"]
+deploymentTarget = "cloudrun"

--- a/replit.nix
+++ b/replit.nix
@@ -1,20 +1,5 @@
 { pkgs }: {
   deps = [
-    pkgs.python310Full
     pkgs.redis
   ];
-  env = {
-    PYTHON_LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
-      # Needed for pandas / numpy
-      pkgs.stdenv.cc.cc.lib
-      pkgs.zlib
-      # Needed for pygame
-      pkgs.glib
-      # Needed for matplotlib
-      pkgs.xorg.libX11
-    ];
-    PYTHONHOME = "${pkgs.python310Full}";
-    PYTHONBIN = "${pkgs.python310Full}/bin/python3.10";
-    LANG = "en_US.UTF-8";
-  };
 }


### PR DESCRIPTION
# Purpose

Fix up .replit and replit.nix

# Changes Made

The some of the python setup code seems to have been removed. This PR brings it back.

# Additional Notes

Decided to leave it as is, but I would recommend not starting a redis server for the deployment every time. It kind of defeats the purpose of redis when it's only local, and it dramatically increases startup times when you scale down to 0 instances.
