### PR TITLE
Add Bedrock, Ollama, Claude2, Cohere, Replicate [100+ LLMs]

### DIFF
--- a/docs/pages/usage/extra-self-host.mdx
+++ b/docs/pages/usage/extra-self-host.mdx
@@ -33,3 +33,34 @@ If you happen to have access to GPT4-32K, fill in the following field:
 ```
 OPENAI_DO_HAVE_32K_MODEL_ACCESS=true
 ```
+### 4. Test other LLMs
+
+#### Huggingface, Palm, Ollama, TogetherAI, AI21, Cohere etc.[Full List](https://docs.litellm.ai/docs/providers)
+
+##### Create OpenAI-proxy
+We'll use [LiteLLM](https://docs.litellm.ai/docs/) to create an OpenAI-compatible endpoint, that translates OpenAI calls to any of the [supported providers](https://docs.litellm.ai/docs/providers).
+
+Example to use a local CodeLLama model from Ollama.ai with Sweep: 
+
+Let's spin up a proxy server to route any OpenAI call from Sweep to Ollama/CodeLlama
+```python
+pip install litellm
+```
+```python
+$ litellm --model ollama/codellama
+
+#INFO: Ollama running on http://0.0.0.0:8000
+```
+
+[Docs](https://docs.litellm.ai/docs/proxy_server)
+
+### Update Sweep
+
+Update your .env 
+
+```shell
+os.environ["OPENAI_API_BASE"] = "http://0.0.0.0:8000"
+os.environ["OPENAI_API_KEY"] = "my-fake-key"
+```
+
+Note: All of Sweep's testing has been done on GPT-4. We've tested and on most of our prompts, even GPT-3.5 and Claude v2 breaks most of the time.

--- a/self_deploy/README.md
+++ b/self_deploy/README.md
@@ -22,6 +22,37 @@ docker build -t sweep-self-deploy .
 docker run -e APP_ID=<app-id> -e PRIVATE_KEY=<pem-value> sweep-self-deploy
 ```
 
+## Test other LLMs
+
+### Huggingface, Palm, Ollama, TogetherAI, AI21, Cohere etc.[Full List](https://docs.litellm.ai/docs/providers)
+
+#### Create OpenAI-proxy
+We'll use [LiteLLM](https://docs.litellm.ai/docs/) to create an OpenAI-compatible endpoint, that translates OpenAI calls to any of the [supported providers](https://docs.litellm.ai/docs/providers).
+
+Example to use a local CodeLLama model from Ollama.ai with Sweep: 
+
+Let's spin up a proxy server to route any OpenAI call from Sweep to Ollama/CodeLlama
+```python
+pip install litellm
+```
+```python
+$ litellm --model ollama/codellama
+
+#INFO: Ollama running on http://0.0.0.0:8000
+```
+
+[Docs](https://docs.litellm.ai/docs/proxy_server)
+
+### Update Sweep
+
+Update your .env 
+
+```shell
+os.environ["OPENAI_API_BASE"] = "http://0.0.0.0:8000"
+os.environ["OPENAI_API_KEY"] = "my-fake-key"
+```
+
+
 ## Contributing
 
 If you have suggestions for how sweep-self-deploy could be improved, or want to report a bug, open an issue! We'd love all and any contributions.

--- a/self_deploy/README.md
+++ b/self_deploy/README.md
@@ -22,37 +22,6 @@ docker build -t sweep-self-deploy .
 docker run -e APP_ID=<app-id> -e PRIVATE_KEY=<pem-value> sweep-self-deploy
 ```
 
-## Test other LLMs
-
-### Huggingface, Palm, Ollama, TogetherAI, AI21, Cohere etc.[Full List](https://docs.litellm.ai/docs/providers)
-
-#### Create OpenAI-proxy
-We'll use [LiteLLM](https://docs.litellm.ai/docs/) to create an OpenAI-compatible endpoint, that translates OpenAI calls to any of the [supported providers](https://docs.litellm.ai/docs/providers).
-
-Example to use a local CodeLLama model from Ollama.ai with Sweep: 
-
-Let's spin up a proxy server to route any OpenAI call from Sweep to Ollama/CodeLlama
-```python
-pip install litellm
-```
-```python
-$ litellm --model ollama/codellama
-
-#INFO: Ollama running on http://0.0.0.0:8000
-```
-
-[Docs](https://docs.litellm.ai/docs/proxy_server)
-
-### Update Sweep
-
-Update your .env 
-
-```shell
-os.environ["OPENAI_API_BASE"] = "http://0.0.0.0:8000"
-os.environ["OPENAI_API_KEY"] = "my-fake-key"
-```
-
-
 ## Contributing
 
 If you have suggestions for how sweep-self-deploy could be improved, or want to report a bug, open an issue! We'd love all and any contributions.


### PR DESCRIPTION
Hi @kevinlu1248 @wwzeng1,

Noticed some users asking for Ollama, etc. support etc. - https://github.com/sweepai/sweep/issues/1400

My PR shows users how to call their LLM providers (bedrock, togetherai, huggingface tgi, replicate, ai21, cohere, ai21 etc.) by pointing your openai endpoint to a [local proxy](https://docs.litellm.ai/docs/proxy_server) they can use for experimentation with self-hosted Sweep.

This makes **no code changes** to Sweep.

Happy to add additional tests/documentation if the initial PR looks good.