### PR TITLE
Fix error on self-deployment where chat_logger is not defined.

### DIFF
--- a/sweepai/handlers/on_ticket.py
+++ b/sweepai/handlers/on_ticket.py
@@ -316,7 +316,7 @@ def on_ticket(
             tickets_allocated = 15
         if is_paying_user:
             tickets_allocated = 500
-        purchased_ticket_count = chat_logger.get_ticket_count(purchased=True)
+        purchased_ticket_count = chat_logger.get_ticket_count(purchased=True) if chat_logger else 0
         ticket_count = (
             max(tickets_allocated - chat_logger.get_ticket_count(), 0)
             + purchased_ticket_count


### PR DESCRIPTION
# Purpose

Fix error on self-deployment where chat_logger is not defined.

# Changes Made

When fetching the purchased_ticket_count, I added a fallback to zero if the chat_logger isn't defined (which is the case when self-hosted).
