### PR TITLE
Add GraphViz dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxcb1 \
     libasound2 \
     libatspi2.0-0 \
+    graphviz \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
# Purpose

Add GraphViz dependency, because the svg graph generation will fail otherwise.

# Changes Made

Please provide a detailed list of the changes made in this pull request.

1. Add GraphViz dependency.

