### PR TITLE
Fixed typo error in contributing file.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,6 @@ Before you submit an issue, please do a search in [open issues](https://github.c
 Use the provided issue template when creating a new issue. Fill in the template with as much detail as possible. The more detail you provide, the more likely that someone can help you.
 Alternatively, you can use Sweep to create a ticket for the problem first. Simply describe the issue or feature request, and Sweep will create a ticket for it. This can help you understand the problem better and guide you in manually solving it.
 You can also use Sweep to create tickets. Simply describe the issue or feature request, and Sweep will create a ticket for it.
-Use the provided issue template when creating a new issue. Fill in the template with as much detail as possible. The more detail you provide, the more likely that someone can help you.
 
 ## Submitting Pull Requests
 


### PR DESCRIPTION
Fixes #2483 

There was a typo error under the contributing file under creating issue section. One line was repeated twice.
Just fixed it.

Looking forward for merging this PR.

# Purpose

Please provide a high-level overview of what this pull request aims to achieve.
Fixed typo error in contributing file.

# Changes Made

Please provide a detailed list of the changes made in this pull request.

1. Deleted the repeated line.
2.  Reduced redundancy 
3.

# Additional Notes

Please provide any additional notes or screenshots here.
When you make a PR, please ping us on Discord at http://discord.gg/sweep.
