### PR TITLE
Remove duplicate line

### DIFF
--- a/sweepai/core/chat.py
+++ b/sweepai/core/chat.py
@@ -91,7 +91,6 @@ class ChatGPT(BaseModel):
             repo_info = get_description(repo)
             repo_description = repo_info["description"]
             repo_info["rules"]
-            repo_info["rules"]
             if repo_description:
                 content += f"{repo_description_prefix_prompt}\n{repo_description}"
         messages = [Message(role="system", content=content, key="system")]


### PR DESCRIPTION
# Purpose

The current implementation of the ChatGPT code contains two consecutive lines (93 and 94) accessing repo_info["rules"] without any subsequent operation or assignment. But they seem redundant, so I removed the line 94.

# Changes Made

1. remove line 94 in sweepai/core/chat.py

# Additional Notes

Please provide any additional notes or screenshots here.
When you make a PR, please ping us on Discord at http://discord.gg/sweep.
