### PR TITLE
Fixed a line number bug in the code chunker

### DIFF
--- a/sweepai/utils/utils.py
+++ b/sweepai/utils/utils.py
@@ -102,7 +102,8 @@ def chunk_tree(
     if len(chunks) == 0:
         return []
     if len(chunks) < 2:
-        return [Span(0, len(chunks[0]))]
+        end = get_line_number(chunks[0].end, source_code)
+        return [Span(0, end)]
     for i in range(len(chunks) - 1):
         chunks[i].end = chunks[i + 1].start
     chunks[-1].end = tree.root_node.end_byte


### PR DESCRIPTION
# Purpose

This PR fixes a bug in [`chunk_tree`](https://github.com/sweepai/sweep/blob/main/sweepai/utils/utils.py#L73) that causes some [`Snippet`](https://github.com/sweepai/sweep/blob/212b446bfa2a2749021eaf6a879596b0ba488836/sweepai/core/entities.py#L366) objects to have incorrect values for the ending line number.

## The Bug

The `chunk_tree` function is supposed to return a list of `Span` objects, each containing `start` and `end` line numbers. These objects are used to create `Snippet` objects in the `chunk_code` function, [here](https://github.com/sweepai/sweep/blob/main/sweepai/utils/utils.py#L315-L320). But if `chunk_node` returns only _one_ chunk (e.g. if the file being processed is small), then the span returned will contain a _byte index_ for the `end` value rather than a line number. This is because byte indices are only converted into line numbers [here](https://github.com/sweepai/sweep/blob/main/sweepai/utils/utils.py#L123-L130), which is _after_ this particular case is handled [here](https://github.com/sweepai/sweep/blob/main/sweepai/utils/utils.py#L104-L105).

# Changes Made

If there's only one chunk, the `end` value of the `Span` returned is a byte index. I changed this to be a line number using the `get_line_number` function.