### PR TITLE
feat: add hatchet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,5 @@ sweepai/sandbox/sandbox.venv
 benchmark
 data
 metals.*
+
+certs

--- a/.gitignore
+++ b/.gitignore
@@ -188,4 +188,12 @@ benchmark
 data
 metals.*
 
+# certificates
 certs
+*.pem
+*.crt
+*.key
+*.srl
+*.csr
+*.pfx
+*.cert

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ Homepage = "https://sweep.dev"
 [tool.poetry.dependencies]
 python = "^3.10"
 PyGithub = "1.58.2"
-loguru = "^0.6.0"
+loguru = "^0.7.2"
 requests = "^2.28.2"
 urllib3 = "<2.0.0"
 config-path = "^1.0.3"
@@ -74,6 +74,7 @@ markdown = "^3.5.1"
 py-spy = "^0.3.14"
 prometheus-fastapi-instrumentator = "^6.1.0"
 rich = "^13.7.0"
+hatchet-sdk = "^0.5.0"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.17.4"

--- a/sweepai/api.py
+++ b/sweepai/api.py
@@ -6,6 +6,7 @@ import json
 import threading
 import time
 from typing import Optional
+from hatchet_sdk import Hatchet, Context
 
 import requests
 from fastapi import (
@@ -260,751 +261,65 @@ def progress(tracking_id: str = Path(...)):
     ticket_progress = TicketProgress.load(tracking_id)
     return ticket_progress.dict()
 
+def init_hatchet() -> Hatchet | None:
+    try:
+        hatchet = Hatchet(debug=True)
+
+        worker = hatchet.worker('github-worker')
+
+        @hatchet.workflow(on_events=["github:webhook"])
+        class OnGithubEvent:
+            """Workflow for handling GitHub events."""
+            
+            @hatchet.step()
+            def run(self, context : Context):
+                event_payload = context.workflow_input()
+
+                request_dict = event_payload.get("request")
+                event = event_payload.get("event")
+
+                run(request_dict, event)
+
+        workflow = OnGithubEvent()
+        worker.register_workflow(workflow)
+
+        # start worker in the background
+        thread = threading.Thread(target=worker.start)
+        thread.start()
+
+        return hatchet
+    except Exception as e:
+        print(f"Failed to initialize Hatchet: {e}, continuing with local mode")
+        return None
+
+hatchet = init_hatchet()    
+
+def handle_github_webhook(event_payload):
+    if hatchet:
+        hatchet.client.event.push("github:webhook", event_payload)
+    else:
+        run(event_payload.get("request"), event_payload.get("event"))
 
 def handle_request(request_dict, event=None):
     """So it can be exported to the listen endpoint."""
     with logger.contextualize(tracking_id="main", env=ENV):
         action = request_dict.get("action")
 
-        def worker():
-            with logger.contextualize(tracking_id="main", env=ENV):
-                match event, action:
-                    case "check_run", "completed":
-                        request = CheckRunCompleted(**request_dict)
-                        _, g = get_github_client(request.installation.id)
-                        repo = g.get_repo(request.repository.full_name)
-                        pull_requests = request.check_run.pull_requests
-                        if pull_requests:
-                            logger.info(pull_requests[0].number)
-                            pr = repo.get_pull(pull_requests[0].number)
-                            if (time.time() - pr.created_at.timestamp()) > 60 * 60 and (
-                                pr.title.startswith("[Sweep Rules]")
-                                or pr.title.startswith("[Sweep GHA Fix]")
-                            ):
-                                after_sha = pr.head.sha
-                                commit = repo.get_commit(after_sha)
-                                check_suites = commit.get_check_suites()
-                                for check_suite in check_suites:
-                                    if check_suite.conclusion == "failure":
-                                        pr.edit(state="closed")
-                                        break
-                            if (
-                                not (time.time() - pr.created_at.timestamp()) > 60 * 15
-                                and request.check_run.conclusion == "failure"
-                                and pr.state == "open"
-                                and get_gha_enabled(repo)
-                                and len(
-                                    [
-                                        comment
-                                        for comment in pr.get_issue_comments()
-                                        if "Fixing PR" in comment.body
-                                    ]
-                                )
-                                < 2
-                            ):
-                                # check if the base branch is passing
-                                commits = repo.get_commits(sha=pr.base.ref)
-                                latest_commit: Commit = commits[0]
-                                if all(
-                                    status != "failure"
-                                    for status in [
-                                        status.state
-                                        for status in latest_commit.get_statuses()
-                                    ]
-                                ):  # base branch is passing
-                                    logs = download_logs(
-                                        request.repository.full_name,
-                                        request.check_run.run_id,
-                                        request.installation.id,
-                                    )
-                                    logs, user_message = clean_logs(logs)
-                                    attributor = request.sender.login
-                                    if attributor.endswith("[bot]"):
-                                        attributor = commit.author.login
-                                    if attributor.endswith("[bot]"):
-                                        attributor = pr.assignee.login
-                                    if attributor.endswith("[bot]"):
-                                        return {
-                                            "success": False,
-                                            "error_message": "The PR was created by a bot, so I won't attempt to fix it.",
-                                        }
-                                    tracking_id = get_hash()
-                                    stack_pr(
-                                        request=f"[Sweep GHA Fix] The GitHub Actions run failed on {request.check_run.head_sha[:7]} ({repo.default_branch}) with the following error logs:\n\n```\n\n{logs}\n\n```",
-                                        pr_number=pr.number,
-                                        username=attributor,
-                                        repo_full_name=repo.full_name,
-                                        installation_id=request.installation.id,
-                                        tracking_id=tracking_id,
-                                        commit_hash=pr.head.sha,
-                                    )
-                        elif (
-                            request.check_run.check_suite.head_branch
-                            == repo.default_branch
-                            and get_gha_enabled(repo)
-                        ):
-                            if request.check_run.conclusion == "failure":
-                                commit = repo.get_commit(request.check_run.head_sha)
-                                attributor = request.sender.login
-                                if attributor.endswith("[bot]"):
-                                    attributor = commit.author.login
-                                if attributor.endswith("[bot]"):
-                                    return {
-                                        "success": False,
-                                        "error_message": "The PR was created by a bot, so I won't attempt to fix it.",
-                                    }
-                                logs = download_logs(
-                                    request.repository.full_name,
-                                    request.check_run.run_id,
-                                    request.installation.id,
-                                )
-                                logs, user_message = clean_logs(logs)
-                                chat_logger = ChatLogger(
-                                    data={
-                                        "username": attributor,
-                                        "title": "[Sweep GHA Fix] Fix the failing GitHub Actions",
-                                    }
-                                )
-                                make_pr(
-                                    title=f"[Sweep GHA Fix] Fix the failing GitHub Actions on {request.check_run.head_sha[:7]} ({repo.default_branch})",
-                                    repo_description=repo.description,
-                                    summary=f"The GitHub Actions run failed with the following error logs:\n\n```\n{logs}\n```",
-                                    repo_full_name=request_dict["repository"][
-                                        "full_name"
-                                    ],
-                                    installation_id=request_dict["installation"]["id"],
-                                    user_token=None,
-                                    use_faster_model=chat_logger.use_faster_model(),
-                                    username=attributor,
-                                    chat_logger=chat_logger,
-                                )
-
-                    case "pull_request", "opened":
-                        _, g = get_github_client(request_dict["installation"]["id"])
-                        repo = g.get_repo(request_dict["repository"]["full_name"])
-                        pr = repo.get_pull(request_dict["pull_request"]["number"])
-                        # if the pr already has a comment from sweep bot do nothing
-                        time.sleep(10)
-                        if any(
-                            comment.user.login == GITHUB_BOT_USERNAME
-                            for comment in pr.get_issue_comments()
-                        ) or pr.title.startswith("Sweep:"):
-                            return {
-                                "success": True,
-                                "reason": "PR already has a comment from sweep bot",
-                            }
-                        rule_buttons = []
-                        repo_rules = get_rules(repo) or []
-                        if repo_rules != [""] and repo_rules != []:
-                            for rule in repo_rules or []:
-                                if rule:
-                                    rule_buttons.append(
-                                        Button(label=f"{RULES_LABEL} {rule}")
-                                    )
-                            if len(repo_rules) == 0:
-                                for rule in DEFAULT_RULES:
-                                    rule_buttons.append(
-                                        Button(label=f"{RULES_LABEL} {rule}")
-                                    )
-                        if rule_buttons:
-                            rules_buttons_list = ButtonList(
-                                buttons=rule_buttons, title=RULES_TITLE
-                            )
-                            pr.create_issue_comment(
-                                rules_buttons_list.serialize() + BOT_SUFFIX
-                            )
-
-                        if pr.mergeable == False:
-                            attributor = pr.user.login
-                            if attributor.endswith("[bot]"):
-                                attributor = pr.assignee.login
-                            if attributor.endswith("[bot]"):
-                                return {
-                                    "success": False,
-                                    "error_message": "The PR was created by a bot, so I won't attempt to fix it.",
-                                }
-                            on_merge_conflict(
-                                pr_number=pr.number,
-                                username=attributor,
-                                repo_full_name=request_dict["repository"]["full_name"],
-                                installation_id=request_dict["installation"]["id"],
-                                tracking_id=get_hash(),
-                            )
-                    case "issues", "opened":
-                        request = IssueRequest(**request_dict)
-                        issue_title_lower = request.issue.title.lower()
-                        if (
-                            issue_title_lower.startswith("sweep")
-                            or "sweep:" in issue_title_lower
-                        ):
-                            _, g = get_github_client(request.installation.id)
-                            repo = g.get_repo(request.repository.full_name)
-
-                            labels = repo.get_labels()
-                            label_names = [label.name for label in labels]
-
-                            if GITHUB_LABEL_NAME not in label_names:
-                                repo.create_label(
-                                    name=GITHUB_LABEL_NAME,
-                                    color=GITHUB_LABEL_COLOR,
-                                    description=GITHUB_LABEL_DESCRIPTION,
-                                )
-                            current_issue = repo.get_issue(number=request.issue.number)
-                            current_issue.add_to_labels(GITHUB_LABEL_NAME)
-                    case "issue_comment", "edited":
-                        request = IssueCommentRequest(**request_dict)
-                        sweep_labeled_issue = GITHUB_LABEL_NAME in [
-                            label.name.lower() for label in request.issue.labels
-                        ]
-                        button_title_match = check_button_title_match(
-                            REVERT_CHANGED_FILES_TITLE,
-                            request.comment.body,
-                            request.changes,
-                        ) or check_button_title_match(
-                            RULES_TITLE,
-                            request.comment.body,
-                            request.changes,
-                        )
-                        if (
-                            request.comment.user.type == "Bot"
-                            and GITHUB_BOT_USERNAME in request.comment.user.login
-                            and request.changes.body_from is not None
-                            and button_title_match
-                            and request.sender.type == "User"
-                        ):
-                            run_on_button_click(request_dict)
-
-                        restart_sweep = False
-                        if (
-                            request.comment.user.type == "Bot"
-                            and GITHUB_BOT_USERNAME in request.comment.user.login
-                            and request.changes.body_from is not None
-                            and check_button_activated(
-                                RESTART_SWEEP_BUTTON,
-                                request.comment.body,
-                                request.changes,
-                            )
-                            and sweep_labeled_issue
-                            and request.sender.type == "User"
-                        ):
-                            # Restart Sweep on this issue
-                            restart_sweep = True
-
-                        if (
-                            request.issue is not None
-                            and sweep_labeled_issue
-                            and request.comment.user.type == "User"
-                            and not request.comment.user.login.startswith("sweep")
-                            and not (
-                                request.issue.pull_request
-                                and request.issue.pull_request.url
-                            )
-                            or restart_sweep
-                        ):
-                            logger.info("New issue comment edited")
-                            request.issue.body = request.issue.body or ""
-                            request.repository.description = (
-                                request.repository.description or ""
-                            )
-
-                            if (
-                                not request.comment.body.strip()
-                                .lower()
-                                .startswith(GITHUB_LABEL_NAME)
-                                and not restart_sweep
-                            ):
-                                logger.info(
-                                    "Comment does not start with 'Sweep', passing"
-                                )
-                                return {
-                                    "success": True,
-                                    "reason": "Comment does not start with 'Sweep', passing",
-                                }
-
-                            call_on_ticket(
-                                title=request.issue.title,
-                                summary=request.issue.body,
-                                issue_number=request.issue.number,
-                                issue_url=request.issue.html_url,
-                                username=request.issue.user.login,
-                                repo_full_name=request.repository.full_name,
-                                repo_description=request.repository.description,
-                                installation_id=request.installation.id,
-                                comment_id=request.comment.id
-                                if not restart_sweep
-                                else None,
-                                edited=True,
-                            )
-                        elif (
-                            request.issue.pull_request
-                            and request.comment.user.type == "User"
-                        ):  # TODO(sweep): set a limit
-                            logger.info(
-                                f"Handling comment on PR: {request.issue.pull_request}"
-                            )
-                            _, g = get_github_client(request.installation.id)
-                            repo = g.get_repo(request.repository.full_name)
-                            pr = repo.get_pull(request.issue.number)
-                            labels = pr.get_labels()
-                            comment = request.comment.body
-                            if (
-                                comment.lower().startswith("sweep:")
-                                or any(
-                                    label.name.lower() == "sweep" for label in labels
-                                )
-                            ) and not BOT_SUFFIX in comment:
-                                pr_change_request = PRChangeRequest(
-                                    params={
-                                        "comment_type": "comment",
-                                        "repo_full_name": request.repository.full_name,
-                                        "repo_description": request.repository.description,
-                                        "comment": request.comment.body,
-                                        "pr_path": None,
-                                        "pr_line_position": None,
-                                        "username": request.comment.user.login,
-                                        "installation_id": request.installation.id,
-                                        "pr_number": request.issue.number,
-                                        "comment_id": request.comment.id,
-                                    },
-                                )
-                                call_on_comment(**pr_change_request.params)
-                    case "issues", "edited":
-                        request = IssueRequest(**request_dict)
-                        if (
-                            GITHUB_LABEL_NAME
-                            in [label.name.lower() for label in request.issue.labels]
-                            and request.sender.type == "User"
-                            and not request.sender.login.startswith("sweep")
-                        ):
-                            logger.info("New issue edited")
-                            call_on_ticket(
-                                title=request.issue.title,
-                                summary=request.issue.body,
-                                issue_number=request.issue.number,
-                                issue_url=request.issue.html_url,
-                                username=request.issue.user.login,
-                                repo_full_name=request.repository.full_name,
-                                repo_description=request.repository.description,
-                                installation_id=request.installation.id,
-                                comment_id=None,
-                            )
-                        else:
-                            logger.info("Issue edited, but not a sweep issue")
-                    case "issues", "labeled":
-                        request = IssueRequest(**request_dict)
-                        if (
-                            any(
-                                label.name.lower() == GITHUB_LABEL_NAME
-                                for label in request.issue.labels
-                            )
-                            and not request.issue.pull_request
-                        ):
-                            request.issue.body = request.issue.body or ""
-                            request.repository.description = (
-                                request.repository.description or ""
-                            )
-                            call_on_ticket(
-                                title=request.issue.title,
-                                summary=request.issue.body,
-                                issue_number=request.issue.number,
-                                issue_url=request.issue.html_url,
-                                username=request.issue.user.login,
-                                repo_full_name=request.repository.full_name,
-                                repo_description=request.repository.description,
-                                installation_id=request.installation.id,
-                                comment_id=None,
-                            )
-                    case "issue_comment", "created":
-                        request = IssueCommentRequest(**request_dict)
-                        if (
-                            request.issue is not None
-                            and GITHUB_LABEL_NAME
-                            in [label.name.lower() for label in request.issue.labels]
-                            and request.comment.user.type == "User"
-                            and not (
-                                request.issue.pull_request
-                                and request.issue.pull_request.url
-                            )
-                            and not (BOT_SUFFIX in request.comment.body)
-                        ):
-                            request.issue.body = request.issue.body or ""
-                            request.repository.description = (
-                                request.repository.description or ""
-                            )
-
-                            if (
-                                not request.comment.body.strip()
-                                .lower()
-                                .startswith(GITHUB_LABEL_NAME)
-                            ):
-                                logger.info(
-                                    "Comment does not start with 'Sweep', passing"
-                                )
-                                return {
-                                    "success": True,
-                                    "reason": "Comment does not start with 'Sweep', passing",
-                                }
-
-                            call_on_ticket(
-                                title=request.issue.title,
-                                summary=request.issue.body,
-                                issue_number=request.issue.number,
-                                issue_url=request.issue.html_url,
-                                username=request.issue.user.login,
-                                repo_full_name=request.repository.full_name,
-                                repo_description=request.repository.description,
-                                installation_id=request.installation.id,
-                                comment_id=request.comment.id,
-                            )
-                        elif (
-                            request.issue.pull_request
-                            and request.comment.user.type == "User"
-                            and not (BOT_SUFFIX in request.comment.body)
-                        ):  # TODO(sweep): set a limit
-                            _, g = get_github_client(request.installation.id)
-                            repo = g.get_repo(request.repository.full_name)
-                            pr = repo.get_pull(request.issue.number)
-                            labels = pr.get_labels()
-                            comment = request.comment.body
-                            if (
-                                comment.lower().startswith("sweep:")
-                                or any(
-                                    label.name.lower() == "sweep" for label in labels
-                                )
-                                and not BOT_SUFFIX in comment
-                            ):
-                                pr_change_request = PRChangeRequest(
-                                    params={
-                                        "comment_type": "comment",
-                                        "repo_full_name": request.repository.full_name,
-                                        "repo_description": request.repository.description,
-                                        "comment": request.comment.body,
-                                        "pr_path": None,
-                                        "pr_line_position": None,
-                                        "username": request.comment.user.login,
-                                        "installation_id": request.installation.id,
-                                        "pr_number": request.issue.number,
-                                        "comment_id": request.comment.id,
-                                    },
-                                )
-                                call_on_comment(**pr_change_request.params)
-                    case "pull_request_review_comment", "created":
-                        request = CommentCreatedRequest(**request_dict)
-                        _, g = get_github_client(request.installation.id)
-                        repo = g.get_repo(request.repository.full_name)
-                        pr = repo.get_pull(request.pull_request.number)
-                        labels = pr.get_labels()
-                        comment = request.comment.body
-                        if (
-                            (
-                                comment.lower().startswith("sweep:")
-                                or any(
-                                    label.name.lower() == "sweep" for label in labels
-                                )
-                            )
-                            and request.comment.user.type == "User"
-                            and not BOT_SUFFIX in comment
-                        ):
-                            pr_change_request = PRChangeRequest(
-                                params={
-                                    "comment_type": "comment",
-                                    "repo_full_name": request.repository.full_name,
-                                    "repo_description": request.repository.description,
-                                    "comment": request.comment.body,
-                                    "pr_path": request.comment.path,
-                                    "pr_line_position": request.comment.original_line,
-                                    "username": request.comment.user.login,
-                                    "installation_id": request.installation.id,
-                                    "pr_number": request.pull_request.number,
-                                    "comment_id": request.comment.id,
-                                },
-                            )
-                            call_on_comment(**pr_change_request.params)
-                    case "pull_request_review_comment", "edited":
-                        request = CommentCreatedRequest(**request_dict)
-                        _, g = get_github_client(request.installation.id)
-                        repo = g.get_repo(request.repository.full_name)
-                        pr = repo.get_pull(request.pull_request.number)
-                        labels = pr.get_labels()
-                        comment = request.comment.body
-                        if (
-                            (
-                                comment.lower().startswith("sweep:")
-                                or any(
-                                    label.name.lower() == "sweep" for label in labels
-                                )
-                            )
-                            and request.comment.user.type == "User"
-                            and not BOT_SUFFIX in comment
-                        ):
-                            pr_change_request = PRChangeRequest(
-                                params={
-                                    "comment_type": "comment",
-                                    "repo_full_name": request.repository.full_name,
-                                    "repo_description": request.repository.description,
-                                    "comment": request.comment.body,
-                                    "pr_path": request.comment.path,
-                                    "pr_line_position": request.comment.original_line,
-                                    "username": request.comment.user.login,
-                                    "installation_id": request.installation.id,
-                                    "pr_number": request.pull_request.number,
-                                    "comment_id": request.comment.id,
-                                },
-                            )
-                            call_on_comment(**pr_change_request.params)
-                    case "installation_repositories", "added":
-                        repos_added_request = ReposAddedRequest(**request_dict)
-                        metadata = {
-                            "installation_id": repos_added_request.installation.id,
-                            "repositories": [
-                                repo.full_name
-                                for repo in repos_added_request.repositories_added
-                            ],
-                        }
-
-                        try:
-                            add_config_to_top_repos(
-                                repos_added_request.installation.id,
-                                repos_added_request.installation.account.login,
-                                repos_added_request.repositories_added,
-                            )
-                        except Exception as e:
-                            logger.exception(f"Failed to add config to top repos: {e}")
-
-                        posthog.capture(
-                            "installation_repositories",
-                            "started",
-                            properties={**metadata},
-                        )
-                        for repo in repos_added_request.repositories_added:
-                            organization, repo_name = repo.full_name.split("/")
-                            posthog.capture(
-                                organization,
-                                "installed_repository",
-                                properties={
-                                    "repo_name": repo_name,
-                                    "organization": organization,
-                                    "repo_full_name": repo.full_name,
-                                },
-                            )
-                    case "installation", "created":
-                        repos_added_request = InstallationCreatedRequest(**request_dict)
-
-                        try:
-                            add_config_to_top_repos(
-                                repos_added_request.installation.id,
-                                repos_added_request.installation.account.login,
-                                repos_added_request.repositories,
-                            )
-                        except Exception as e:
-                            logger.exception(f"Failed to add config to top repos: {e}")
-                    case "pull_request", "edited":
-                        request = PREdited(**request_dict)
-
-                        if (
-                            request.pull_request.user.login == GITHUB_BOT_USERNAME
-                            and not request.sender.login.endswith("[bot]")
-                            and DISCORD_FEEDBACK_WEBHOOK_URL is not None
-                        ):
-                            good_button = check_button_activated(
-                                SWEEP_GOOD_FEEDBACK,
-                                request.pull_request.body,
-                                request.changes,
-                            )
-                            bad_button = check_button_activated(
-                                SWEEP_BAD_FEEDBACK,
-                                request.pull_request.body,
-                                request.changes,
-                            )
-
-                            if good_button or bad_button:
-                                emoji = "😕"
-                                if good_button:
-                                    emoji = "👍"
-                                elif bad_button:
-                                    emoji = "👎"
-                                data = {
-                                    "content": f"{emoji} {request.pull_request.html_url} ({request.sender.login})\n{request.pull_request.commits} commits, {request.pull_request.changed_files} files: +{request.pull_request.additions}, -{request.pull_request.deletions}"
-                                }
-                                headers = {"Content-Type": "application/json"}
-                                response = requests.post(
-                                    DISCORD_FEEDBACK_WEBHOOK_URL,
-                                    data=json.dumps(data),
-                                    headers=headers,
-                                )
-
-                                # Send feedback to PostHog
-                                posthog.capture(
-                                    request.sender.login,
-                                    "feedback",
-                                    properties={
-                                        "repo_name": request.repository.full_name,
-                                        "pr_url": request.pull_request.html_url,
-                                        "pr_commits": request.pull_request.commits,
-                                        "pr_additions": request.pull_request.additions,
-                                        "pr_deletions": request.pull_request.deletions,
-                                        "pr_changed_files": request.pull_request.changed_files,
-                                        "username": request.sender.login,
-                                        "good_button": good_button,
-                                        "bad_button": bad_button,
-                                    },
-                                )
-
-                                def remove_buttons_from_description(body):
-                                    """
-                                    Replace:
-                                    ### PR Feedback...
-                                    ...
-                                    # (until it hits the next #)
-
-                                    with
-                                    ### PR Feedback: {emoji}
-                                    #
-                                    """
-                                    lines = body.split("\n")
-                                    if not lines[0].startswith("### PR Feedback"):
-                                        return None
-                                    # Find when the second # occurs
-                                    i = 0
-                                    for i, line in enumerate(lines):
-                                        if line.startswith("#") and i > 0:
-                                            break
-
-                                    return "\n".join(
-                                        [
-                                            f"### PR Feedback: {emoji}",
-                                            *lines[i:],
-                                        ]
-                                    )
-
-                                # Update PR description to remove buttons
-                                try:
-                                    _, g = get_github_client(request.installation.id)
-                                    repo = g.get_repo(request.repository.full_name)
-                                    pr = repo.get_pull(request.pull_request.number)
-                                    new_body = remove_buttons_from_description(
-                                        request.pull_request.body
-                                    )
-                                    if new_body is not None:
-                                        pr.edit(body=new_body)
-                                except SystemExit:
-                                    raise SystemExit
-                                except Exception as e:
-                                    logger.exception(
-                                        f"Failed to edit PR description: {e}"
-                                    )
-                    case "pull_request", "closed":
-                        pr_request = PRRequest(**request_dict)
-                        (
-                            organization,
-                            repo_name,
-                        ) = pr_request.repository.full_name.split("/")
-                        commit_author = pr_request.pull_request.user.login
-                        merged_by = (
-                            pr_request.pull_request.merged_by.login
-                            if pr_request.pull_request.merged_by
-                            else None
-                        )
-                        if (
-                            GITHUB_BOT_USERNAME == commit_author
-                            and merged_by is not None
-                        ):
-                            event_name = "merged_sweep_pr"
-                            if pr_request.pull_request.title.startswith("[config]"):
-                                event_name = "config_pr_merged"
-                            elif pr_request.pull_request.title.startswith(
-                                "[Sweep Rules]"
-                            ):
-                                event_name = "sweep_rules_pr_merged"
-                            posthog.capture(
-                                merged_by,
-                                event_name,
-                                properties={
-                                    "repo_name": repo_name,
-                                    "organization": organization,
-                                    "repo_full_name": pr_request.repository.full_name,
-                                    "username": merged_by,
-                                    "additions": pr_request.pull_request.additions,
-                                    "deletions": pr_request.pull_request.deletions,
-                                    "total_changes": pr_request.pull_request.additions
-                                    + pr_request.pull_request.deletions,
-                                },
-                            )
-                        chat_logger = ChatLogger({"username": merged_by})
-                    case "push", None:
-                        if (
-                            event != "pull_request"
-                            or request_dict["base"]["merged"] == True
-                        ):
-                            chat_logger = ChatLogger(
-                                {"username": request_dict["pusher"]["name"]}
-                            )
-                            # on merge
-                            call_on_merge(request_dict, chat_logger)
-                            ref = request_dict["ref"] if "ref" in request_dict else ""
-                            if ref.startswith("refs/heads") and not ref.startswith(
-                                "ref/heads/sweep"
-                            ):
-                                _, g = get_github_client(
-                                    request_dict["installation"]["id"]
-                                )
-                                repo = g.get_repo(
-                                    request_dict["repository"]["full_name"]
-                                )
-                                if ref[len("refs/heads/") :] == SweepConfig.get_branch(
-                                    repo
-                                ):
-                                    update_sweep_prs_v2(
-                                        request_dict["repository"]["full_name"],
-                                        installation_id=request_dict["installation"][
-                                            "id"
-                                        ],
-                                    )
-                            if ref.startswith("refs/heads"):
-                                branch_name = ref[len("refs/heads/") :]
-                                # Check if the branch has an associated PR
-
-                                org_name, repo_name = request_dict["repository"][
-                                    "full_name"
-                                ].split("/")
-                                pulls = repo.get_pulls(
-                                    state="open",
-                                    sort="created",
-                                    head=org_name + ":" + branch_name,
-                                )
-                                for pr in pulls:
-                                    logger.info(
-                                        f"PR associated with branch {branch_name}: #{pr.number} - {pr.title}"
-                                    )
-                                    if pr.mergeable == False:
-                                        attributor = pr.user.login
-                                        if attributor.endswith("[bot]"):
-                                            attributor = pr.assignee.login
-                                        if attributor.endswith("[bot]"):
-                                            return {
-                                                "success": False,
-                                                "error_message": "The PR was created by a bot, so I won't attempt to fix it.",
-                                            }
-                                        on_merge_conflict(
-                                            pr_number=pr.number,
-                                            username=pr.user.login,
-                                            repo_full_name=request_dict["repository"][
-                                                "full_name"
-                                            ],
-                                            installation_id=request_dict[
-                                                "installation"
-                                            ]["id"],
-                                            tracking_id=get_hash(),
-                                        )
-                    case "ping", None:
-                        return {"message": "pong"}
-                    case _:
-                        return {"error": "Unsupported type"}
-
         try:
-            worker()
+            # Send the event to Hatchet
+            handle_github_webhook(
+                {
+                    "request": request_dict,
+                    "event": event,
+                }
+            )
         except Exception as e:
-            discord_log_error(str(e), priority=1)
+            logger.exception(f"Failed to send event to Hatchet: {e}")
+
+        # try:
+        #     worker()
+        # except Exception as e:
+        #     discord_log_error(str(e), priority=1)
         logger.info(f"Done handling {event}, {action}")
         return {"success": True}
 
@@ -1078,3 +393,742 @@ def update_sweep_prs_v2(repo_full_name: str, installation_id: int):
                 )
     except:
         logger.warning("Failed to update sweep PRs")
+
+def run(request_dict, event):
+    action = request_dict.get("action")
+
+    with logger.contextualize(tracking_id="main", env=ENV):
+        match event, action:
+            case "check_run", "completed":
+                request = CheckRunCompleted(**request_dict)
+                _, g = get_github_client(request.installation.id)
+                repo = g.get_repo(request.repository.full_name)
+                pull_requests = request.check_run.pull_requests
+                if pull_requests:
+                    logger.info(pull_requests[0].number)
+                    pr = repo.get_pull(pull_requests[0].number)
+                    if (time.time() - pr.created_at.timestamp()) > 60 * 60 and (
+                        pr.title.startswith("[Sweep Rules]")
+                        or pr.title.startswith("[Sweep GHA Fix]")
+                    ):
+                        after_sha = pr.head.sha
+                        commit = repo.get_commit(after_sha)
+                        check_suites = commit.get_check_suites()
+                        for check_suite in check_suites:
+                            if check_suite.conclusion == "failure":
+                                pr.edit(state="closed")
+                                break
+                    if (
+                        not (time.time() - pr.created_at.timestamp()) > 60 * 15
+                        and request.check_run.conclusion == "failure"
+                        and pr.state == "open"
+                        and get_gha_enabled(repo)
+                        and len(
+                            [
+                                comment
+                                for comment in pr.get_issue_comments()
+                                if "Fixing PR" in comment.body
+                            ]
+                        )
+                        < 2
+                    ):
+                        # check if the base branch is passing
+                        commits = repo.get_commits(sha=pr.base.ref)
+                        latest_commit: Commit = commits[0]
+                        if all(
+                            status != "failure"
+                            for status in [
+                                status.state
+                                for status in latest_commit.get_statuses()
+                            ]
+                        ):  # base branch is passing
+                            logs = download_logs(
+                                request.repository.full_name,
+                                request.check_run.run_id,
+                                request.installation.id,
+                            )
+                            logs, user_message = clean_logs(logs)
+                            attributor = request.sender.login
+                            if attributor.endswith("[bot]"):
+                                attributor = commit.author.login
+                            if attributor.endswith("[bot]"):
+                                attributor = pr.assignee.login
+                            if attributor.endswith("[bot]"):
+                                return {
+                                    "success": False,
+                                    "error_message": "The PR was created by a bot, so I won't attempt to fix it.",
+                                }
+                            tracking_id = get_hash()
+                            stack_pr(
+                                request=f"[Sweep GHA Fix] The GitHub Actions run failed on {request.check_run.head_sha[:7]} ({repo.default_branch}) with the following error logs:\n\n```\n\n{logs}\n\n```",
+                                pr_number=pr.number,
+                                username=attributor,
+                                repo_full_name=repo.full_name,
+                                installation_id=request.installation.id,
+                                tracking_id=tracking_id,
+                                commit_hash=pr.head.sha,
+                            )
+                elif (
+                    request.check_run.check_suite.head_branch
+                    == repo.default_branch
+                    and get_gha_enabled(repo)
+                ):
+                    if request.check_run.conclusion == "failure":
+                        commit = repo.get_commit(request.check_run.head_sha)
+                        attributor = request.sender.login
+                        if attributor.endswith("[bot]"):
+                            attributor = commit.author.login
+                        if attributor.endswith("[bot]"):
+                            return {
+                                "success": False,
+                                "error_message": "The PR was created by a bot, so I won't attempt to fix it.",
+                            }
+                        logs = download_logs(
+                            request.repository.full_name,
+                            request.check_run.run_id,
+                            request.installation.id,
+                        )
+                        logs, user_message = clean_logs(logs)
+                        chat_logger = ChatLogger(
+                            data={
+                                "username": attributor,
+                                "title": "[Sweep GHA Fix] Fix the failing GitHub Actions",
+                            }
+                        )
+                        make_pr(
+                            title=f"[Sweep GHA Fix] Fix the failing GitHub Actions on {request.check_run.head_sha[:7]} ({repo.default_branch})",
+                            repo_description=repo.description,
+                            summary=f"The GitHub Actions run failed with the following error logs:\n\n```\n{logs}\n```",
+                            repo_full_name=request_dict["repository"][
+                                "full_name"
+                            ],
+                            installation_id=request_dict["installation"]["id"],
+                            user_token=None,
+                            use_faster_model=chat_logger.use_faster_model(),
+                            username=attributor,
+                            chat_logger=chat_logger,
+                        )
+
+            case "pull_request", "opened":
+                _, g = get_github_client(request_dict["installation"]["id"])
+                repo = g.get_repo(request_dict["repository"]["full_name"])
+                pr = repo.get_pull(request_dict["pull_request"]["number"])
+                # if the pr already has a comment from sweep bot do nothing
+                time.sleep(10)
+                if any(
+                    comment.user.login == GITHUB_BOT_USERNAME
+                    for comment in pr.get_issue_comments()
+                ) or pr.title.startswith("Sweep:"):
+                    return {
+                        "success": True,
+                        "reason": "PR already has a comment from sweep bot",
+                    }
+                rule_buttons = []
+                repo_rules = get_rules(repo) or []
+                if repo_rules != [""] and repo_rules != []:
+                    for rule in repo_rules or []:
+                        if rule:
+                            rule_buttons.append(
+                                Button(label=f"{RULES_LABEL} {rule}")
+                            )
+                    if len(repo_rules) == 0:
+                        for rule in DEFAULT_RULES:
+                            rule_buttons.append(
+                                Button(label=f"{RULES_LABEL} {rule}")
+                            )
+                if rule_buttons:
+                    rules_buttons_list = ButtonList(
+                        buttons=rule_buttons, title=RULES_TITLE
+                    )
+                    pr.create_issue_comment(
+                        rules_buttons_list.serialize() + BOT_SUFFIX
+                    )
+
+                if pr.mergeable == False:
+                    attributor = pr.user.login
+                    if attributor.endswith("[bot]"):
+                        attributor = pr.assignee.login
+                    if attributor.endswith("[bot]"):
+                        return {
+                            "success": False,
+                            "error_message": "The PR was created by a bot, so I won't attempt to fix it.",
+                        }
+                    on_merge_conflict(
+                        pr_number=pr.number,
+                        username=attributor,
+                        repo_full_name=request_dict["repository"]["full_name"],
+                        installation_id=request_dict["installation"]["id"],
+                        tracking_id=get_hash(),
+                    )
+            case "issues", "opened":
+                request = IssueRequest(**request_dict)
+                issue_title_lower = request.issue.title.lower()
+                if (
+                    issue_title_lower.startswith("sweep")
+                    or "sweep:" in issue_title_lower
+                ):
+                    _, g = get_github_client(request.installation.id)
+                    repo = g.get_repo(request.repository.full_name)
+
+                    labels = repo.get_labels()
+                    label_names = [label.name for label in labels]
+
+                    if GITHUB_LABEL_NAME not in label_names:
+                        repo.create_label(
+                            name=GITHUB_LABEL_NAME,
+                            color=GITHUB_LABEL_COLOR,
+                            description=GITHUB_LABEL_DESCRIPTION,
+                        )
+                    current_issue = repo.get_issue(number=request.issue.number)
+                    current_issue.add_to_labels(GITHUB_LABEL_NAME)
+            case "issue_comment", "edited":
+                request = IssueCommentRequest(**request_dict)
+                sweep_labeled_issue = GITHUB_LABEL_NAME in [
+                    label.name.lower() for label in request.issue.labels
+                ]
+                button_title_match = check_button_title_match(
+                    REVERT_CHANGED_FILES_TITLE,
+                    request.comment.body,
+                    request.changes,
+                ) or check_button_title_match(
+                    RULES_TITLE,
+                    request.comment.body,
+                    request.changes,
+                )
+                if (
+                    request.comment.user.type == "Bot"
+                    and GITHUB_BOT_USERNAME in request.comment.user.login
+                    and request.changes.body_from is not None
+                    and button_title_match
+                    and request.sender.type == "User"
+                ):
+                    run_on_button_click(request_dict)
+
+                restart_sweep = False
+                if (
+                    request.comment.user.type == "Bot"
+                    and GITHUB_BOT_USERNAME in request.comment.user.login
+                    and request.changes.body_from is not None
+                    and check_button_activated(
+                        RESTART_SWEEP_BUTTON,
+                        request.comment.body,
+                        request.changes,
+                    )
+                    and sweep_labeled_issue
+                    and request.sender.type == "User"
+                ):
+                    # Restart Sweep on this issue
+                    restart_sweep = True
+
+                if (
+                    request.issue is not None
+                    and sweep_labeled_issue
+                    and request.comment.user.type == "User"
+                    and not request.comment.user.login.startswith("sweep")
+                    and not (
+                        request.issue.pull_request
+                        and request.issue.pull_request.url
+                    )
+                    or restart_sweep
+                ):
+                    logger.info("New issue comment edited")
+                    request.issue.body = request.issue.body or ""
+                    request.repository.description = (
+                        request.repository.description or ""
+                    )
+
+                    if (
+                        not request.comment.body.strip()
+                        .lower()
+                        .startswith(GITHUB_LABEL_NAME)
+                        and not restart_sweep
+                    ):
+                        logger.info(
+                            "Comment does not start with 'Sweep', passing"
+                        )
+                        return {
+                            "success": True,
+                            "reason": "Comment does not start with 'Sweep', passing",
+                        }
+
+                    call_on_ticket(
+                        title=request.issue.title,
+                        summary=request.issue.body,
+                        issue_number=request.issue.number,
+                        issue_url=request.issue.html_url,
+                        username=request.issue.user.login,
+                        repo_full_name=request.repository.full_name,
+                        repo_description=request.repository.description,
+                        installation_id=request.installation.id,
+                        comment_id=request.comment.id
+                        if not restart_sweep
+                        else None,
+                        edited=True,
+                    )
+                elif (
+                    request.issue.pull_request
+                    and request.comment.user.type == "User"
+                ):  # TODO(sweep): set a limit
+                    logger.info(
+                        f"Handling comment on PR: {request.issue.pull_request}"
+                    )
+                    _, g = get_github_client(request.installation.id)
+                    repo = g.get_repo(request.repository.full_name)
+                    pr = repo.get_pull(request.issue.number)
+                    labels = pr.get_labels()
+                    comment = request.comment.body
+                    if (
+                        comment.lower().startswith("sweep:")
+                        or any(
+                            label.name.lower() == "sweep" for label in labels
+                        )
+                    ) and not BOT_SUFFIX in comment:
+                        pr_change_request = PRChangeRequest(
+                            params={
+                                "comment_type": "comment",
+                                "repo_full_name": request.repository.full_name,
+                                "repo_description": request.repository.description,
+                                "comment": request.comment.body,
+                                "pr_path": None,
+                                "pr_line_position": None,
+                                "username": request.comment.user.login,
+                                "installation_id": request.installation.id,
+                                "pr_number": request.issue.number,
+                                "comment_id": request.comment.id,
+                            },
+                        )
+                        call_on_comment(**pr_change_request.params)
+            case "issues", "edited":
+                request = IssueRequest(**request_dict)
+                if (
+                    GITHUB_LABEL_NAME
+                    in [label.name.lower() for label in request.issue.labels]
+                    and request.sender.type == "User"
+                    and not request.sender.login.startswith("sweep")
+                ):
+                    logger.info("New issue edited")
+                    call_on_ticket(
+                        title=request.issue.title,
+                        summary=request.issue.body,
+                        issue_number=request.issue.number,
+                        issue_url=request.issue.html_url,
+                        username=request.issue.user.login,
+                        repo_full_name=request.repository.full_name,
+                        repo_description=request.repository.description,
+                        installation_id=request.installation.id,
+                        comment_id=None,
+                    )
+                else:
+                    logger.info("Issue edited, but not a sweep issue")
+            case "issues", "labeled":
+                request = IssueRequest(**request_dict)
+                if (
+                    any(
+                        label.name.lower() == GITHUB_LABEL_NAME
+                        for label in request.issue.labels
+                    )
+                    and not request.issue.pull_request
+                ):
+                    request.issue.body = request.issue.body or ""
+                    request.repository.description = (
+                        request.repository.description or ""
+                    )
+                    call_on_ticket(
+                        title=request.issue.title,
+                        summary=request.issue.body,
+                        issue_number=request.issue.number,
+                        issue_url=request.issue.html_url,
+                        username=request.issue.user.login,
+                        repo_full_name=request.repository.full_name,
+                        repo_description=request.repository.description,
+                        installation_id=request.installation.id,
+                        comment_id=None,
+                    )
+            case "issue_comment", "created":
+                request = IssueCommentRequest(**request_dict)
+                if (
+                    request.issue is not None
+                    and GITHUB_LABEL_NAME
+                    in [label.name.lower() for label in request.issue.labels]
+                    and request.comment.user.type == "User"
+                    and not (
+                        request.issue.pull_request
+                        and request.issue.pull_request.url
+                    )
+                    and not (BOT_SUFFIX in request.comment.body)
+                ):
+                    request.issue.body = request.issue.body or ""
+                    request.repository.description = (
+                        request.repository.description or ""
+                    )
+
+                    if (
+                        not request.comment.body.strip()
+                        .lower()
+                        .startswith(GITHUB_LABEL_NAME)
+                    ):
+                        logger.info(
+                            "Comment does not start with 'Sweep', passing"
+                        )
+                        return {
+                            "success": True,
+                            "reason": "Comment does not start with 'Sweep', passing",
+                        }
+
+                    call_on_ticket(
+                        title=request.issue.title,
+                        summary=request.issue.body,
+                        issue_number=request.issue.number,
+                        issue_url=request.issue.html_url,
+                        username=request.issue.user.login,
+                        repo_full_name=request.repository.full_name,
+                        repo_description=request.repository.description,
+                        installation_id=request.installation.id,
+                        comment_id=request.comment.id,
+                    )
+                elif (
+                    request.issue.pull_request
+                    and request.comment.user.type == "User"
+                    and not (BOT_SUFFIX in request.comment.body)
+                ):  # TODO(sweep): set a limit
+                    _, g = get_github_client(request.installation.id)
+                    repo = g.get_repo(request.repository.full_name)
+                    pr = repo.get_pull(request.issue.number)
+                    labels = pr.get_labels()
+                    comment = request.comment.body
+                    if (
+                        comment.lower().startswith("sweep:")
+                        or any(
+                            label.name.lower() == "sweep" for label in labels
+                        )
+                        and not BOT_SUFFIX in comment
+                    ):
+                        pr_change_request = PRChangeRequest(
+                            params={
+                                "comment_type": "comment",
+                                "repo_full_name": request.repository.full_name,
+                                "repo_description": request.repository.description,
+                                "comment": request.comment.body,
+                                "pr_path": None,
+                                "pr_line_position": None,
+                                "username": request.comment.user.login,
+                                "installation_id": request.installation.id,
+                                "pr_number": request.issue.number,
+                                "comment_id": request.comment.id,
+                            },
+                        )
+                        call_on_comment(**pr_change_request.params)
+            case "pull_request_review_comment", "created":
+                request = CommentCreatedRequest(**request_dict)
+                _, g = get_github_client(request.installation.id)
+                repo = g.get_repo(request.repository.full_name)
+                pr = repo.get_pull(request.pull_request.number)
+                labels = pr.get_labels()
+                comment = request.comment.body
+                if (
+                    (
+                        comment.lower().startswith("sweep:")
+                        or any(
+                            label.name.lower() == "sweep" for label in labels
+                        )
+                    )
+                    and request.comment.user.type == "User"
+                    and not BOT_SUFFIX in comment
+                ):
+                    pr_change_request = PRChangeRequest(
+                        params={
+                            "comment_type": "comment",
+                            "repo_full_name": request.repository.full_name,
+                            "repo_description": request.repository.description,
+                            "comment": request.comment.body,
+                            "pr_path": request.comment.path,
+                            "pr_line_position": request.comment.original_line,
+                            "username": request.comment.user.login,
+                            "installation_id": request.installation.id,
+                            "pr_number": request.pull_request.number,
+                            "comment_id": request.comment.id,
+                        },
+                    )
+                    call_on_comment(**pr_change_request.params)
+            case "pull_request_review_comment", "edited":
+                request = CommentCreatedRequest(**request_dict)
+                _, g = get_github_client(request.installation.id)
+                repo = g.get_repo(request.repository.full_name)
+                pr = repo.get_pull(request.pull_request.number)
+                labels = pr.get_labels()
+                comment = request.comment.body
+                if (
+                    (
+                        comment.lower().startswith("sweep:")
+                        or any(
+                            label.name.lower() == "sweep" for label in labels
+                        )
+                    )
+                    and request.comment.user.type == "User"
+                    and not BOT_SUFFIX in comment
+                ):
+                    pr_change_request = PRChangeRequest(
+                        params={
+                            "comment_type": "comment",
+                            "repo_full_name": request.repository.full_name,
+                            "repo_description": request.repository.description,
+                            "comment": request.comment.body,
+                            "pr_path": request.comment.path,
+                            "pr_line_position": request.comment.original_line,
+                            "username": request.comment.user.login,
+                            "installation_id": request.installation.id,
+                            "pr_number": request.pull_request.number,
+                            "comment_id": request.comment.id,
+                        },
+                    )
+                    call_on_comment(**pr_change_request.params)
+            case "installation_repositories", "added":
+                repos_added_request = ReposAddedRequest(**request_dict)
+                metadata = {
+                    "installation_id": repos_added_request.installation.id,
+                    "repositories": [
+                        repo.full_name
+                        for repo in repos_added_request.repositories_added
+                    ],
+                }
+
+                try:
+                    add_config_to_top_repos(
+                        repos_added_request.installation.id,
+                        repos_added_request.installation.account.login,
+                        repos_added_request.repositories_added,
+                    )
+                except Exception as e:
+                    logger.exception(f"Failed to add config to top repos: {e}")
+
+                posthog.capture(
+                    "installation_repositories",
+                    "started",
+                    properties={**metadata},
+                )
+                for repo in repos_added_request.repositories_added:
+                    organization, repo_name = repo.full_name.split("/")
+                    posthog.capture(
+                        organization,
+                        "installed_repository",
+                        properties={
+                            "repo_name": repo_name,
+                            "organization": organization,
+                            "repo_full_name": repo.full_name,
+                        },
+                    )
+            case "installation", "created":
+                repos_added_request = InstallationCreatedRequest(**request_dict)
+
+                try:
+                    add_config_to_top_repos(
+                        repos_added_request.installation.id,
+                        repos_added_request.installation.account.login,
+                        repos_added_request.repositories,
+                    )
+                except Exception as e:
+                    logger.exception(f"Failed to add config to top repos: {e}")
+            case "pull_request", "edited":
+                request = PREdited(**request_dict)
+
+                if (
+                    request.pull_request.user.login == GITHUB_BOT_USERNAME
+                    and not request.sender.login.endswith("[bot]")
+                    and DISCORD_FEEDBACK_WEBHOOK_URL is not None
+                ):
+                    good_button = check_button_activated(
+                        SWEEP_GOOD_FEEDBACK,
+                        request.pull_request.body,
+                        request.changes,
+                    )
+                    bad_button = check_button_activated(
+                        SWEEP_BAD_FEEDBACK,
+                        request.pull_request.body,
+                        request.changes,
+                    )
+
+                    if good_button or bad_button:
+                        emoji = "😕"
+                        if good_button:
+                            emoji = "👍"
+                        elif bad_button:
+                            emoji = "👎"
+                        data = {
+                            "content": f"{emoji} {request.pull_request.html_url} ({request.sender.login})\n{request.pull_request.commits} commits, {request.pull_request.changed_files} files: +{request.pull_request.additions}, -{request.pull_request.deletions}"
+                        }
+                        headers = {"Content-Type": "application/json"}
+                        response = requests.post(
+                            DISCORD_FEEDBACK_WEBHOOK_URL,
+                            data=json.dumps(data),
+                            headers=headers,
+                        )
+
+                        # Send feedback to PostHog
+                        posthog.capture(
+                            request.sender.login,
+                            "feedback",
+                            properties={
+                                "repo_name": request.repository.full_name,
+                                "pr_url": request.pull_request.html_url,
+                                "pr_commits": request.pull_request.commits,
+                                "pr_additions": request.pull_request.additions,
+                                "pr_deletions": request.pull_request.deletions,
+                                "pr_changed_files": request.pull_request.changed_files,
+                                "username": request.sender.login,
+                                "good_button": good_button,
+                                "bad_button": bad_button,
+                            },
+                        )
+
+                        def remove_buttons_from_description(body):
+                            """
+                            Replace:
+                            ### PR Feedback...
+                            ...
+                            # (until it hits the next #)
+
+                            with
+                            ### PR Feedback: {emoji}
+                            #
+                            """
+                            lines = body.split("\n")
+                            if not lines[0].startswith("### PR Feedback"):
+                                return None
+                            # Find when the second # occurs
+                            i = 0
+                            for i, line in enumerate(lines):
+                                if line.startswith("#") and i > 0:
+                                    break
+
+                            return "\n".join(
+                                [
+                                    f"### PR Feedback: {emoji}",
+                                    *lines[i:],
+                                ]
+                            )
+
+                        # Update PR description to remove buttons
+                        try:
+                            _, g = get_github_client(request.installation.id)
+                            repo = g.get_repo(request.repository.full_name)
+                            pr = repo.get_pull(request.pull_request.number)
+                            new_body = remove_buttons_from_description(
+                                request.pull_request.body
+                            )
+                            if new_body is not None:
+                                pr.edit(body=new_body)
+                        except SystemExit:
+                            raise SystemExit
+                        except Exception as e:
+                            logger.exception(
+                                f"Failed to edit PR description: {e}"
+                            )
+            case "pull_request", "closed":
+                pr_request = PRRequest(**request_dict)
+                (
+                    organization,
+                    repo_name,
+                ) = pr_request.repository.full_name.split("/")
+                commit_author = pr_request.pull_request.user.login
+                merged_by = (
+                    pr_request.pull_request.merged_by.login
+                    if pr_request.pull_request.merged_by
+                    else None
+                )
+                if (
+                    GITHUB_BOT_USERNAME == commit_author
+                    and merged_by is not None
+                ):
+                    event_name = "merged_sweep_pr"
+                    if pr_request.pull_request.title.startswith("[config]"):
+                        event_name = "config_pr_merged"
+                    elif pr_request.pull_request.title.startswith(
+                        "[Sweep Rules]"
+                    ):
+                        event_name = "sweep_rules_pr_merged"
+                    posthog.capture(
+                        merged_by,
+                        event_name,
+                        properties={
+                            "repo_name": repo_name,
+                            "organization": organization,
+                            "repo_full_name": pr_request.repository.full_name,
+                            "username": merged_by,
+                            "additions": pr_request.pull_request.additions,
+                            "deletions": pr_request.pull_request.deletions,
+                            "total_changes": pr_request.pull_request.additions
+                            + pr_request.pull_request.deletions,
+                        },
+                    )
+                chat_logger = ChatLogger({"username": merged_by})
+            case "push", None:
+                if (
+                    event != "pull_request"
+                    or request_dict["base"]["merged"] == True
+                ):
+                    chat_logger = ChatLogger(
+                        {"username": request_dict["pusher"]["name"]}
+                    )
+                    # on merge
+                    call_on_merge(request_dict, chat_logger)
+                    ref = request_dict["ref"] if "ref" in request_dict else ""
+                    if ref.startswith("refs/heads") and not ref.startswith(
+                        "ref/heads/sweep"
+                    ):
+                        _, g = get_github_client(
+                            request_dict["installation"]["id"]
+                        )
+                        repo = g.get_repo(
+                            request_dict["repository"]["full_name"]
+                        )
+                        if ref[len("refs/heads/") :] == SweepConfig.get_branch(
+                            repo
+                        ):
+                            update_sweep_prs_v2(
+                                request_dict["repository"]["full_name"],
+                                installation_id=request_dict["installation"][
+                                    "id"
+                                ],
+                            )
+                    if ref.startswith("refs/heads"):
+                        branch_name = ref[len("refs/heads/") :]
+                        # Check if the branch has an associated PR
+
+                        org_name, repo_name = request_dict["repository"][
+                            "full_name"
+                        ].split("/")
+                        pulls = repo.get_pulls(
+                            state="open",
+                            sort="created",
+                            head=org_name + ":" + branch_name,
+                        )
+                        for pr in pulls:
+                            logger.info(
+                                f"PR associated with branch {branch_name}: #{pr.number} - {pr.title}"
+                            )
+                            if pr.mergeable == False:
+                                attributor = pr.user.login
+                                if attributor.endswith("[bot]"):
+                                    attributor = pr.assignee.login
+                                if attributor.endswith("[bot]"):
+                                    return {
+                                        "success": False,
+                                        "error_message": "The PR was created by a bot, so I won't attempt to fix it.",
+                                    }
+                                on_merge_conflict(
+                                    pr_number=pr.number,
+                                    username=pr.user.login,
+                                    repo_full_name=request_dict["repository"][
+                                        "full_name"
+                                    ],
+                                    installation_id=request_dict[
+                                        "installation"
+                                    ]["id"],
+                                    tracking_id=get_hash(),
+                                )
+            case "ping", None:
+                return {"message": "pong"}
+            case _:
+                return {"error": "Unsupported type"}
+
+


### PR DESCRIPTION
# Purpose

This PR adds [Hatchet](https://hatchet.run) to the Sweep webhook service. This aims to improve event observability and make debugging workflows and workers easier. 

# Changes Made

Please provide a detailed list of the changes made in this pull request.

1. Modifies `api.py` to define a worker via Hatchet. When Hatchet env vars (see below) are available, the API will push an event to Hatchet, and the execution will be picked up by the worker. When Hatchet env vars are not available, the request handler will continue as before. 
2. Add several certificate file types to `.gitignore` to make very sure that none are leaked. Hatchet uses mTLS which requires a set of certificates.
3. Bumps the `loguru` version as the Hatchet version is ahead of the Sweep version of loguru. This can be reverted if necessary.

# Additional Notes

See the docs for setup here: https://docs.hatchet.run/python-sdk/setup

In particular, the following env vars must be set:

```
HATCHET_CLIENT_TENANT_ID=<tenant-id>
HATCHET_CLIENT_TLS_ROOT_CA_FILE=./certs/ca.cert
HATCHET_CLIENT_TLS_CERT_FILE=./certs/client-worker.pem
HATCHET_CLIENT_TLS_KEY_FILE=./certs/client-worker.key
HATCHET_CLIENT_TLS_SERVER_NAME=<hatchet-domain>
HATCHET_CLIENT_HOST_PORT=<hatchet-domain>:443
```