### PR TITLE
fix: update hatchet to latest version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ markdown = "^3.5.1"
 py-spy = "^0.3.14"
 prometheus-fastapi-instrumentator = "^6.1.0"
 rich = "^13.7.0"
-hatchet-sdk = "^0.5.0"
+hatchet-sdk = "^0.7.1"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.17.4"


### PR DESCRIPTION
# Purpose

This PR updates Hatchet to the latest version and moves the tasks into the foreground if Hatchet is enabled, using Hatchet's native thread management instead. 

# Changes Made

Please provide a detailed list of the changes made in this pull request.

1. Updates Hatchet to `v0.7.1`. 
2. Only spawns a new `threading.Thread` if Hatchet is not enabled (for tickets and comments). If Hatchet is enabled, it uses Hatchet workflows to trigger the ticket and comment runs. 

# Additional Notes

See setup instructions here: https://docs.hatchet.run/python-sdk/setup