### PR TITLE
Add Support for Elm Language Using @codemirror/legacy-modes

### DIFF
--- a/platform/components/dashboard/FileSelector.tsx
+++ b/platform/components/dashboard/FileSelector.tsx
@@ -7,6 +7,7 @@ import { javascript } from "@codemirror/lang-javascript";
 import { java } from "@codemirror/lang-java";
 import { python } from "@codemirror/lang-python";
 import { html } from "@codemirror/lang-html";
+import { elm } from "@codemirror/legacy-modes/mode/elm";
 
 import CodeMirror, {
   EditorState,
@@ -15,7 +16,7 @@ import CodeMirror, {
 } from "@uiw/react-codemirror";
 import CodeMirrorMerge from "react-codemirror-merge";
 import { indentWithTab } from "@codemirror/commands";
-import { indentUnit } from "@codemirror/language";
+import { indentUnit, LanguageSupport, StreamLanguage } from "@codemirror/language";
 import { FaArrowLeft } from "react-icons/fa6";
 
 const getLanguage = (ext: string) => {
@@ -29,6 +30,7 @@ const getLanguage = (ext: string) => {
     erb: html(),
     py: python(),
     kt: java(),
+    elm: new LanguageSupport(StreamLanguage.define(elm)),
   };
   return languageMap[ext] || javascript();
 };

--- a/platform/package.json
+++ b/platform/package.json
@@ -30,6 +30,7 @@
     "@codemirror/lang-python": "^6.1.3",
     "@codemirror/lang-xml": "^6.0.2",
     "@codemirror/language": "^6.10.0",
+    "@codemirror/legacy-modes": "^6.3.3",
     "@codemirror/state": "^6.4.0",
     "@codemirror/view": "^6.23.0",
     "@inquirer/password": "^2.0.0",

--- a/platform/pnpm-lock.yaml
+++ b/platform/pnpm-lock.yaml
@@ -26,6 +26,9 @@ dependencies:
   '@codemirror/language':
     specifier: ^6.10.0
     version: 6.10.0
+  '@codemirror/legacy-modes':
+    specifier: ^6.3.3
+    version: 6.3.3
   '@codemirror/state':
     specifier: ^6.4.0
     version: 6.4.0
@@ -1564,6 +1567,12 @@ packages:
       '@lezer/highlight': 1.2.0
       '@lezer/lr': 1.4.0
       style-mod: 4.1.0
+    dev: false
+
+  /@codemirror/legacy-modes@6.3.3:
+    resolution: {integrity: sha512-X0Z48odJ0KIoh/HY8Ltz75/4tDYc9msQf1E/2trlxFaFFhgjpVHjZ/BCXe1Lk7s4Gd67LL/CeEEHNI+xHOiESg==}
+    dependencies:
+      '@codemirror/language': 6.10.0
     dev: false
 
   /@codemirror/lint@6.4.2:

--- a/sweepai/agents/assistant_wrapper.py
+++ b/sweepai/agents/assistant_wrapper.py
@@ -87,6 +87,7 @@ allowed_exts = [
     "xlsx",
     "xml",
     "zip",
+    "elm",
 ]
 
 

--- a/sweepai/utils/utils.py
+++ b/sweepai/utils/utils.py
@@ -169,6 +169,7 @@ extension_to_language = {
     "html": "html",
     "vue": "html",
     "php": "php",
+    "elm": "elm",
 }
 
 


### PR DESCRIPTION
# Purpose

This PR adds Elm language support.

# Changes Made

I did 2 main things:

1. Added `@codemirror/legacy-modes` to our project to get Elm mode.
2. Made Elm mode work in our setup by using some CodeMirror 6 tools.

# Additional Notes

Adding Elm makes our editor more inclusive for more people.
<img width="1001" alt="image" src="https://github.com/sweepai/sweep/assets/4601603/80d7521e-17d7-484a-96e9-4edb3cb246eb">

Please tell me how it works for you or if you see any problems.
🙏🙏🥳