### PR TITLE
FIXED: Chunker was not eliminating empty chunks

### DIFF
--- a/sweepai/utils/utils.py
+++ b/sweepai/utils/utils.py
@@ -133,10 +133,7 @@ def chunk_tree(
         line_chunks.append(Span(start_line, max(start_line, end_line)))
 
     # 5. Eliminating empty chunks
-    new_line_chunks = []
-    for chunk in line_chunks:
-        if len(chunk) > 0:
-            new_line_chunks.append(chunk)
+    line_chunks = [chunk for chunk in line_chunks if len(chunk) > 0]
 
     # 6. Coalescing last chunk if it's too small
     if len(line_chunks) > 1 and len(line_chunks[-1]) < coalesce:


### PR DESCRIPTION
# Purpose

Fixes a bug in the AST-based chunker where empty chunks were not actually being filtered out.

# Changes Made

The issue was that a new array, `new_line_chunks`, was created and holds only non-empty chunks, but this array never actually gets returned by the chunker.

I changed it so we simply eliminate empty chunks from the `line_chunks` array instead.
