### PR TITLE
fix

### DIFF
--- a/sweepai/config/client.py
+++ b/sweepai/config/client.py
@@ -109,6 +109,8 @@ class SweepConfig(BaseModel):
         "pnpm-lock.yaml",
         "LICENSE",
         "poetry.lock",
+        'package-lock.json',
+        'package.json'
     ]
     # cutoff for when we output truncated versions of strings, this is an arbitrary number and can be changed
     truncation_cutoff: int = 20000


### PR DESCRIPTION
filters out useless files like package-lock.json, will add a message later on letting the user know it got dropped and was not reviewed